### PR TITLE
Adds German translations

### DIFF
--- a/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGenerator.kt
+++ b/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGenerator.kt
@@ -11,6 +11,7 @@ class FuzzyTextGenerator {
                 "es" -> FuzzyTextSpanish()
                 "nl" -> FuzzyTextDutch()
                 "en-num" -> FuzzyTextEnglishNumbered()
+				"de" -> FuzzyTextGerman()
                 else -> FuzzyTextEnglish()
 
             }.generate(hour, min)

--- a/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGerman.kt
+++ b/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGerman.kt
@@ -54,7 +54,7 @@ class FuzzyTextGerman : FuzzyTextInterface {
                 else -> when (hour) {
                     11 -> "zwölf"
                     else -> when {
-						min > 51 -> "Mitternacht"
+						min > 49 -> "Mitternacht"
 						else -> "zwölf"
 					}
                 }

--- a/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGerman.kt
+++ b/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGerman.kt
@@ -32,12 +32,16 @@ class FuzzyTextGerman : FuzzyTextInterface {
                 hour % 12 == 11 -> "elf"
                 else -> when (hour) {
                     12 -> "zwölf"
-                    else -> "zwölf"
+                    else -> when {
+						min < 10 -> "Mitternacht"
+						else -> "zwölf"
+					}				
                 }
             }
         } else {
             when {
-                hour % 12 == 1 -> "zwei"
+                hour % 12 == 0 -> "eins"
+				hour % 12 == 1 -> "zwei"
                 hour % 12 == 2 -> "drei"
                 hour % 12 == 3 -> "vier"
                 hour % 12 == 4 -> "fünf"
@@ -49,8 +53,10 @@ class FuzzyTextGerman : FuzzyTextInterface {
                 hour % 12 == 10 -> "elf"
                 else -> when (hour) {
                     11 -> "zwölf"
-                    23 -> "zwölf"
-                    else -> "eins"
+                    else -> when {
+						min > 51 -> "Mitternacht"
+						else -> "zwölf"
+					}
                 }
             }
         }

--- a/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGerman.kt
+++ b/shared/src/main/java/net/tuurlievens/fuzzyclock/text/FuzzyTextGerman.kt
@@ -1,0 +1,61 @@
+package net.tuurlievens.fuzzyclock.text
+
+class FuzzyTextGerman : FuzzyTextInterface {
+
+    // hour is a 24-hour based integer
+    override fun generate(hour: Int, min: Int): String {
+
+        // convert from minute count to fuzzy text
+        val mintext = when {
+            min < 2 -> "gerade"
+            min < 10 -> "kurz nach"
+            min < 20 -> "viertel nach"
+            min < 40 -> "halb" // hour switches here
+            min < 50 -> "viertel vor"
+            min < 58 -> "kurz vor"
+            else -> "gerade"
+        }
+
+        // german uses "half <hour+1>"
+        val hourtext = if (min < 20) {
+            when {
+                hour % 12 == 1 -> "eins"
+                hour % 12 == 2 -> "zwei"
+                hour % 12 == 3 -> "drei"
+                hour % 12 == 4 -> "vier"
+                hour % 12 == 5 -> "fünf"
+                hour % 12 == 6 -> "sechs"
+                hour % 12 == 7 -> "sieben"
+                hour % 12 == 8 -> "acht"
+                hour % 12 == 9 -> "neun"
+                hour % 12 == 10 -> "zehn"
+                hour % 12 == 11 -> "elf"
+                else -> when (hour) {
+                    12 -> "zwölf"
+                    else -> "zwölf"
+                }
+            }
+        } else {
+            when {
+                hour % 12 == 1 -> "zwei"
+                hour % 12 == 2 -> "drei"
+                hour % 12 == 3 -> "vier"
+                hour % 12 == 4 -> "fünf"
+                hour % 12 == 5 -> "sechs"
+                hour % 12 == 6 -> "sieben"
+                hour % 12 == 7 -> "acht"
+                hour % 12 == 8 -> "neun"
+                hour % 12 == 9 -> "zehn"
+                hour % 12 == 10 -> "elf"
+                else -> when (hour) {
+                    11 -> "zwölf"
+                    23 -> "zwölf"
+                    else -> "eins"
+                }
+            }
+        }
+
+        return "$mintext\n$hourtext"
+    }
+
+}

--- a/shared/src/main/res/values-de/strings.xml
+++ b/shared/src/main/res/values-de/strings.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="suite_name">Fuzzy Clock</string>
+    <string name="screensaver_name">Fuzzy Clock Screensaver</string>
+    <string name="widget_name">Fuzzy Clock Widget</string>
+    <string name="watchface_name">Fuzzy Clock Watchface</string>
+
+    <string name="notif_service_name">Notification Listener</string>
+
+    <!-- General -->
+    <string name="save">Speichern</string>
+    <string name="settings">Einstellungen</string>
+    <string name="visible">sichtbar</string>
+    <string name="hidden">unsichtbar</string>
+    <string name="error">Fehler</string>
+
+    <!-- Strings related to Settings -->
+    <string name="pref_category_display">Anzeige</string>
+    <string name="pref_category_style">Textstil</string>
+    <string name="pref_category_working">Konfiguration</string>
+    <string name="pref_category_elements">Elemente</string>
+    <string name="pref_category_textformat">Textformat</string>
+    <string name="pref_category_system">System</string>
+    <string name="pref_category_complications">Probleme</string>
+
+    <string name="pref_title_maxTranslationDisplacement">Prozentuale Verschiebung gegen Einbrennen (0.0 – 1.0)</string>
+    <string name="pref_title_updateSeconds">Aktualisiere Uhr alle x Sekunden</string>
+    <string name="pref_title_language">Sprache</string>
+    <string name="pref_title_fontSize">Fontgröße</string>
+    <string name="pref_title_textAlignment">Textausrichtung</string>
+    <string name="pref_title_foregroundColor">Textfarbe</string>
+    <string name="pref_title_backgroundColor">Hintergrundfarbe</string>
+    <string name="pref_title_removeLineBreak">Zeige Stunden in einer Zeile an</string>
+    <string name="pref_title_brightScreen">Hellerer Bildschirm</string>
+    <string name="pref_title_notifState">Zeige Benachrichtigungen</string>
+    <string name="pref_title_showBattery">Zeige Batteriezustand</string>
+    <string name="pref_title_showDate">Zeige Datum</string>
+    <string name="pref_title_simplerDate">Vereinfachtes Datum</string>
+    <string name="pref_title_showStatusbar">Zeige Statussymbole</string>
+    <string name="pref_title_showDigitalClock">Zeige digitale Uhr</string>
+    <string name="pref_title_fontFamily">Schriftfamilie</string>
+    <string name="pref_title_useDateFont">Benutze Schriftfamilie für das Datum</string>
+    <string name="pref_title_showShadow">Zeige Schatten</string>
+    <string name="pref_title_shadowSize">Schattengröße</string>
+    <string name="pref_title_shadowColor">Schattenfarbe</string>
+    <string name="pref_title_emphasis">Hervorheben</string>
+    <string name="pref_title_scaling">Qualität (höher bedeutet weniger Verschwommenheit)</string>
+
+    <string name="msg_notificationaccess">Für diese Funktion muss die Berechtigung für Benachrichtigungen erteilt werden</string>
+    <string name="msg_editbtn">Tipp die rechte obere Ecke an, um das Widget zu editieren</string>
+    <string name="msg_notsupported">Nicht in dieser Android-Version unterstützt</string>
+    <string name="msg_secondscreen">Tipp das Watchface um alle Probleme zu sehen</string>
+    <string name="msg_validationfail">Diese Daten sind nicht gültig</string>
+
+    <string-array name="pref_list_language_titles">
+        <item>Abhängig von der Geräteeinstellung</item>
+        <item>Englisch</item>
+        <item>Englisch (Zahlen)</item>
+        <item>Niederländisch</item>
+        <item>Spanisch</item>
+		<item>Deutsch</item>
+    </string-array>
+
+    <string-array name="pref_list_textAlignment_titles">
+        <item>Links</item>
+        <item>Mitte</item>
+        <item>Rechts</item>
+    </string-array>
+
+    <string-array name="pref_list_color_titles">
+        <item>Schwarz</item>
+        <item>Grau</item>
+        <item>Weiß</item>
+        <item>Rot</item>
+        <item>Pink</item>
+        <item>Violett</item>
+        <item>Dunkles Violett</item>
+        <item>Indigo</item>
+        <item>Blau</item>
+        <item>Hellblau</item>
+        <item>Cyan</item>
+        <item>Türkis</item>
+        <item>Grün</item>
+        <item>Hellgrün</item>
+        <item>Limette</item>
+        <item>Gelb</item>
+        <item>Bernstein</item>
+        <item>Orange</item>
+        <item>Dunkles Orange</item>
+        <item>Braun</item>
+        <item>Dunkles Grau</item>
+        <item>Blau-Grau</item>
+    </string-array>
+
+    <string-array name="pref_list_notifState_titles">
+        <item>Sichtbar</item>
+        <item>Nur Anzahl</item>
+        <item>Unsichtbar</item>
+    </string-array>
+
+    <string-array name="pref_list_visibility_titles">
+        <item>Nie</item>
+        <item>Wenn wach</item>
+        <item>Immer</item>
+    </string-array>
+
+    <string name="title_fontFamily_sans">Sans serif</string>
+    <string name="title_fontFamily_serif">Serif</string>
+    <string name="title_fontFamily_mono">Monospace</string>
+
+    <string-array name="pref_list_emphasis_titles">
+        <item>Normal</item>
+        <item>Fett</item>
+        <item>Kursiv</item>
+        <item>Fett kursiv</item>
+    </string-array>
+
+</resources>


### PR DESCRIPTION
I added a German translation. Never worked with git or kotlin before and just tried to make changes analogue to what was already there.
Translations for hours and minutes are very basic, not considering e.g. "Mitternacht" (midnight), as "halb Mitternacht" doesn't sound right and more logic would need to be added for that.
Also, southern German uses "three quarters of hour+1" instead of standard/northern German "one quarter before hour+1". I would like to add this as well, but I guess this would have to be included as its own language(?), and I don't know if you want the project spammed with dialects. ;-)